### PR TITLE
Don't let MPSL mix the MPDM variable with mp parent version.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -125,27 +125,27 @@ fi
 # MPDM
 echo -n "Looking for MPDM... "
 
-for MPDM in ./mpdm/ ../mpdm/ NOTFOUND ; do
-    if [ -d $MPDM ] && [ -f $MPDM/mpdm.h ] ; then
+for MPDMi in ./mpdm/ ../mpdm/ NOTFOUND ; do
+    if [ -d $MPDMi ] && [ -f $MPDMi/mpdm.h ] ; then
         break
     fi
 done
 
-if [ "$MPDM" != "NOTFOUND" ] ; then
-    echo "-I$MPDM" >> config.cflags
-    echo "-L$MPDM -lmpdm" >> config.ldflags
-    echo "OK ($MPDM)"
+if [ "$MPDMi" != "NOTFOUND" ] ; then
+    echo "-I$MPDMi" >> config.cflags
+    echo "-L$MPDMi -lmpdm" >> config.ldflags
+    echo "OK ($MPDMi)"
 else
     echo "No"
     exit 1
 fi
 
 echo
-(cd $MPDM ; ./config.sh $CONF_ARGS)
+(cd $MPDMi ; ./config.sh $CONF_ARGS)
 echo
 
 # import MPDM build configuration
-. $MPDM.build.sh
+. $MPDMi.build.sh
 
 LDFLAGS="$LDFLAGS -lm"
 
@@ -166,11 +166,11 @@ if [ ! -z "$CONFOPT_DEFAULT_COMPILER" ] ; then
     echo "#define CONFOPT_DEFAULT_COMPILER \"$CONFOPT_DEFAULT_COMPILER\"" >> config.h
 fi
 
-cat $MPDM/config.ldflags >> config.ldflags
+cat $MPDMi/config.ldflags >> config.ldflags
 echo "-lm" >> config.ldflags
 
 # if win32, the interpreter is called mpsl.exe
-grep CONFOPT_WIN32 ${MPDM}/config.h >/dev/null && TARGET=${TARGET}.exe
+grep CONFOPT_WIN32 ${MPDMi}/config.h >/dev/null && TARGET=${TARGET}.exe
 
 
 #########################################################
@@ -182,8 +182,8 @@ echo "AR=$AR" >> makefile.opts
 echo "CFLAGS=$CFLAGS" >> makefile.opts
 echo "YACC=$YACC" >> makefile.opts
 
-echo "MPDM=$MPDM" >> makefile.opts
-grep DOCS $MPDM/makefile.opts >> makefile.opts
+echo "MPDMi=$MPDMi" >> makefile.opts
+grep DOCS $MPDMi/makefile.opts >> makefile.opts
 echo "VERSION=$VERSION" >> makefile.opts
 echo "PREFIX=\$(DESTDIR)$PREFIX" >> makefile.opts
 echo "DOCDIR=\$(DESTDIR)$DOCDIR" >> makefile.opts
@@ -201,7 +201,7 @@ echo "AR='$AR'" >> .build.sh
 echo "YACC='$YACC'" >> .build.sh
 echo "CFLAGS='$CFLAGS'" >> .build.sh
 echo "LDFLAGS='$LDFLAGS'" >> .build.sh
-echo "MPDM='$MPDM'" >> .build.sh
+echo "MPDMi='$MPDMi'" >> .build.sh
 
 #########################################################
 

--- a/makefile.in
+++ b/makefile.in
@@ -9,7 +9,7 @@ clean:
 	rm -f $(TARGET) $(LIB) $(OBJS) mpslc *.o tags *.tar.gz *-stress
 
 LIBS:
-	$(MAKE) -C $(MPDM) libmpdm.a
+	$(MAKE) -C $(MPDMi) libmpdm.a
 
 PROJ=mpsl
 
@@ -28,13 +28,13 @@ version:
 .c.o:
 	$(CC) $(CFLAGS) `cat config.cflags` -c $<
 
-y.tab.h: $(MPDM)/mpdm.h mpsl.y
+y.tab.h: $(MPDMi)/mpdm.h mpsl.y
 	$(YACC) -d mpsl.y
 
-y.tab.c: $(MPDM)/mpdm.h mpsl.y
+y.tab.c: $(MPDMi)/mpdm.h mpsl.y
 	$(YACC) -d mpsl.y
 
-lex.yy.c: $(MPDM)/mpdm.h mpsl.l
+lex.yy.c: $(MPDMi)/mpdm.h mpsl.l
 	flex mpsl.l
 
 mpsl_l.o: lex.yy.c y.tab.h
@@ -45,12 +45,12 @@ mpsl_y.o: y.tab.c
 
 dep:
 	gcc `cat config.cflags` -MM *.c | \
-		sed -e 's;$(MPDM)/;$$(MPDM)/;g' > makefile.depend
+		sed -e 's;$(MPDMi)/;$$(MPDMi)/;g' > makefile.depend
 
 $(LIB): $(OBJS)
 	$(AR) rv $(LIB) $(OBJS)
 
-$(TARGET): $(LIB) $(MPDM)/libmpdm.a
+$(TARGET): $(LIB) $(MPDMi)/libmpdm.a
 	$(CC) $(CFLAGS) -L. -lmpsl `cat config.ldflags` -o $@
 
 mpslc: mpslc.in
@@ -59,7 +59,7 @@ mpslc: mpslc.in
 stress-test: mpsl-stress
 	./mpsl-stress
 
-mpsl-stress: mpsl-stress.c $(LIB) $(MPDM)/libmpdm.a
+mpsl-stress: mpsl-stress.c $(LIB) $(MPDMi)/libmpdm.a
 	$(CC) $(CFLAGS) `cat config.cflags` mpsl-stress.c \
 		-L. -lmpsl `cat config.ldflags` -o $@
 


### PR DESCRIPTION
Currently, MPSL create a MPDM variable in its makefile and so does MP. But since MPSL's makefile variables are included after MP own variable in MP's config.sh, this variable is overwriting and breaking the one detected by MP. 
Thus, the current code only allow a single directory hierarchy, that is: `mdpm mp-5.x mpsl` on the same level, because MPSL detects MPDM in `../mpdm` which is, by luck, also valid once in `mp-5.x` directory.

This changes makes MPSL's MPDM variable independent of MP own MPDM variable and allow any directory.